### PR TITLE
add more 4-letter word hints for level 11

### DIFF
--- a/levels/level011/ghee.html
+++ b/levels/level011/ghee.html
@@ -1,0 +1,2 @@
+Hey! You found a word in a random sequence of strings.<br>
+This is not the solution.

--- a/levels/level011/host.html
+++ b/levels/level011/host.html
@@ -1,0 +1,2 @@
+Hey! You found a word in a random sequence of strings.<br>
+This is not the solution.

--- a/levels/level011/sore.html
+++ b/levels/level011/sore.html
@@ -1,0 +1,2 @@
+Hey! You found a word in a random sequence of strings.<br>
+This is not the solution.


### PR DESCRIPTION
In my frustration while doing this question, I compared all of the commit 4-grams to the standard unix dictionary (/usr/share/dict/words) and found the words `['bowl', 'host', 'ghee', 'sore', 'tirl', 'oint', 'seck', 'onym']`.

In a related note, I found that all words that were part of some dictionary word were `['ayco', 'rovo', 'flec', 'rvac', 'keer', 'nneq', 'iceu', 'dohr', 'bowl', 'njac', 'clye', 'eaho', 'pija', 'denb', 'tzon', 'eedk', 'hcon', 'arry', 'nocr', 'atvi', 'yciu', 'omul', 'salr', 'orri', 'ollw', 'apax', 'otie', 'tscu', 'akof', 'nhaz', 'imat', 'cyth', 'nlig', 'tpro', 'lsha', 'uboh', 'affs', 'moyl', 'dazi', 'easa', 'iseh', 'dalp', 'noom', 'kerl', 'icac', 'rios', 'ridy', 'afum', 'puil', 'host', 'etel', 'nyai', 'ghee', 'idhs', 'pulg', 'nuet', 'lbar', 'iptu', 'feti', 'xadi', 'clea', 'vagu', 'sore', 'auga', 'rhet', 'tirl', 'aotz', 'pywi', 'nirv', 'oint', 'ganu', 'iere', 'mnei', 'rika', 'racq', 'guei', 'oteb', 'seck', 'lduc', 'atda', 'rget', 'lcen', 'vere', 'zapo', 'mysi', 'gick', 'efic', 'rkne', 'liro', 'pown', 'iete', 'atpu', 'ycel', 'onym', 'aset', 'wrid', 'duca', 'requ']`.
